### PR TITLE
Ajuste no funcionamento do botao autopreencher

### DIFF
--- a/hooks/useFormApi.js
+++ b/hooks/useFormApi.js
@@ -40,7 +40,7 @@ export function useFormsApi() {
       setChaveNM(chaveClassificacaoNM);
       setResults((r) => ({ ...r, form1: { success: true } }));
 
-      // 👉 Envio do Form2
+      // Envio do Form2
       try {
         await api.post("/api/form2", {
           chaveClassificacaoNM,
@@ -58,7 +58,7 @@ export function useFormsApi() {
         }));
       }
 
-      // 👉 Envio do Form3
+      // Envio do Form3
       try {
         await api.post("/api/form3", {
           chaveClassificacaoNM,
@@ -89,5 +89,24 @@ export function useFormsApi() {
     }
   };
 
-  return { submitForms, loading, error, success, chaveNM, results };
+  const resetResults = () => {
+    setResults({
+      form1: null,
+      form2: null,
+      form3: null,
+    });
+    setChaveNM(null);
+    setError(null);
+    setSuccess(false);
+  };
+
+  return {
+    submitForms,
+    loading,
+    error,
+    success,
+    chaveNM,
+    results,
+    resetResults,
+  };
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,7 +17,7 @@ export default function GeneralForms() {
   const [opcaoSelecionada, setOpcaoSelecionada] = useState("");
   const [scoreData, setScoreData] = useState(null);
 
-  const { submitForms, results, chaveNM } = useFormsApi();
+  const { submitForms, results, chaveNM, resetResults } = useFormsApi();
 
   const [openDropdowns, setOpenDropdowns] = useState({
     form1: false,
@@ -47,6 +47,10 @@ export default function GeneralForms() {
     }
 
     try {
+      // Resetar dados e resultados anteriores
+      resetResults();
+      setScoreData(null);
+
       const dadosGlebaTalhao =
         jsonSelecionado.item[0]?.item[0]?.request?.body?.raw || [];
       const dadosLaboratorio =


### PR DESCRIPTION
Ajuste para que ao clicar novamente no botao autopreencher os resultados do teste anterior serem "apagados" da tela apenas visualmente.